### PR TITLE
Updates process new bibtext entires button

### DIFF
--- a/source/refnotes/macros/bibtex/process-entries.tid
+++ b/source/refnotes/macros/bibtex/process-entries.tid
@@ -23,7 +23,7 @@ type: text/vnd.tiddlywiki
 
 \define process-entries(title:"Process New Bibtex Entries")
 <$button> $title$
-<$list filter="[!tag[bibtex-entry]has[bibtex-title]]">
+<$list filter="[has[bibtex-title]!tag[bibtex-entry]]">
 <<tag-entries>>
 <<title-tolowercase>>
 </$list>

--- a/source/refnotes/macros/bibtex/process-entries.tid
+++ b/source/refnotes/macros/bibtex/process-entries.tid
@@ -23,7 +23,7 @@ type: text/vnd.tiddlywiki
 
 \define process-entries(title:"Process New Bibtex Entries")
 <$button> $title$
-<$list filter="[has[bibtex-title]]">
+<$list filter="[!tag[bibtex-entry]has[bibtex-title]]">
 <<tag-entries>>
 <<title-tolowercase>>
 </$list>


### PR DESCRIPTION
Process new bibtext entries button now checks if an entry already has been processed preventing processing big lists of already processed tiddlers.